### PR TITLE
docker build 플랫폼 제거

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
  version: "3"
  services:
     kafkaui_rbac:
-      platform: linux/amd64
       build:
         dockerfile: Dockerfile
       image: kafkaui_rbac:local


### PR DESCRIPTION
도커 이미지가 이미지를 빌드하는 각 OS 환경을 따라가도록 변경
